### PR TITLE
Add rolling-cuda image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,22 @@ jobs:
             target: gazebo
             platforms: "linux/amd64"
           - label: ros2
+            tag: rolling-cuda
+            target: base
+            platforms: "linux/amd64"
+          - label: ros2
+            tag: rolling-cuda
+            target: dev
+            platforms: "linux/amd64"
+          - label: ros2
+            tag: rolling-cuda
+            target: full
+            platforms: "linux/amd64"
+          - label: ros2
+            tag: rolling-cuda
+            target: gazebo
+            platforms: "linux/amd64"
+          - label: ros2
             tag: jazzy
             target: base
             platforms: "linux/amd64,linux/arm64"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -89,6 +89,7 @@
       "options": [
         "noetic",
         "rolling",
+        "rolling-cuda",
         "jazzy",
         "iron",
         "iron-cuda",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mccabe==0.7.0
 mdurl==0.1.2
-packaging==24.1
+packaging==24.2
 pycodestyle==2.12.1
 pydantic==2.9.2
 pydantic_core==2.23.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.12
 shellingham==1.5.4
 tqdm==4.67.0
-typer==0.13.0
+typer==0.13.1
 typing_extensions==4.12.2
 urllib3==2.2.3
 websocket-client==1.8.0

--- a/ros2/README.md
+++ b/ros2/README.md
@@ -21,6 +21,13 @@ rolling
 * [rolling-full](https://github.com/athackst/dockerfiles/blob/main/ros2/rolling.Dockerfile)
 * [rolling-gazebo](https://github.com/athackst/dockerfiles/blob/main/ros2/rolling.Dockerfile)
 
+rolling-cuda
+  
+* [rolling-cuda-base](https://github.com/athackst/dockerfiles/blob/main/ros2/rolling-cuda.Dockerfile)
+* [rolling-cuda-dev](https://github.com/athackst/dockerfiles/blob/main/ros2/rolling-cuda.Dockerfile)
+* [rolling-cuda-full](https://github.com/athackst/dockerfiles/blob/main/ros2/rolling-cuda.Dockerfile)
+* [rolling-cuda-gazebo](https://github.com/athackst/dockerfiles/blob/main/ros2/rolling-cuda.Dockerfile)
+
 jazzy
   
 * [jazzy-base](https://github.com/athackst/dockerfiles/blob/main/ros2/jazzy.Dockerfile)

--- a/ros2/rolling-cuda.Dockerfile
+++ b/ros2/rolling-cuda.Dockerfile
@@ -1,0 +1,153 @@
+##############################################
+# Created from template ros2.dockerfile.jinja
+##############################################
+
+###########################################
+# Base image
+###########################################
+FROM nvidia/cuda:12.6.2-cudnn-runtime-ubuntu24.04 AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install language
+RUN apt-get update && apt-get install -y \
+  locales \
+  && locale-gen en_US.UTF-8 \
+  && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+  && rm -rf /var/lib/apt/lists/*
+ENV LANG=en_US.UTF-8
+
+# Install timezone
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get install -y tzdata \
+  && dpkg-reconfigure --frontend noninteractive tzdata \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get -y upgrade \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install common programs
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    gnupg2 \
+    lsb-release \
+    sudo \
+    software-properties-common \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install ROS2
+RUN sudo add-apt-repository universe \
+  && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null \
+  && apt-get update && apt-get install -y --no-install-recommends \
+    ros-rolling-ros-base \
+    python3-argcomplete \
+  && rm -rf /var/lib/apt/lists/*
+
+################
+# Expose the nvidia driver to allow opengl 
+# Dependencies for glvnd and X11.
+################
+RUN apt-get update \
+ && apt-get install -y -qq --no-install-recommends \
+  libglvnd0 \
+  libgl1 \
+  libglx0 \
+  libegl1 \
+  libxext6 \
+  libx11-6
+
+# Env vars for the nvidia-container-runtime.
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=graphics,utility,compute
+ENV QT_X11_NO_MITSHM=1
+
+ENV ROS_DISTRO=rolling
+ENV AMENT_PREFIX_PATH=/opt/ros/rolling
+ENV COLCON_PREFIX_PATH=/opt/ros/rolling
+ENV LD_LIBRARY_PATH=/opt/ros/rolling/lib
+ENV PATH=/opt/ros/rolling/bin:$PATH
+ENV PYTHONPATH=/opt/ros/rolling/local/lib/python3.12/dist-packages:/opt/ros/rolling/lib/python3.12/site-packages
+ENV ROS_PYTHON_VERSION=3
+ENV ROS_VERSION=2
+ENV DEBIAN_FRONTEND=
+
+###########################################
+#  Develop image
+###########################################
+FROM base AS dev
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  bash-completion \
+  build-essential \
+  cmake \
+  gdb \
+  git \
+  openssh-client \
+  python3-argcomplete \
+  python3-pip \
+  ros-dev-tools \
+  ros-rolling-ament-* \
+  vim \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN rosdep init || echo "rosdep already initialized"
+
+ARG USERNAME=ros
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Check if "ubuntu" user exists, delete it if it does, then create the desired user
+RUN if getent passwd ubuntu > /dev/null 2>&1; then \
+        userdel -r ubuntu && \
+        echo "Deleted existing ubuntu user"; \
+    fi && \
+    groupadd --gid $USER_GID $USERNAME && \
+    useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME && \
+    echo "Created new user $USERNAME"
+
+# Add sudo support for the non-root user
+RUN apt-get update && apt-get install -y sudo \
+  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+  && chmod 0440 /etc/sudoers.d/$USERNAME \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set up autocompletion for user
+RUN apt-get update && apt-get install -y git-core bash-completion \
+  && echo "if [ -f /opt/ros/${ROS_DISTRO}/setup.bash ]; then source /opt/ros/${ROS_DISTRO}/setup.bash; fi" >> /home/$USERNAME/.bashrc \
+  && echo "if [ -f /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash ]; then source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash; fi" >> /home/$USERNAME/.bashrc \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV DEBIAN_FRONTEND=
+ENV AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS=1
+
+###########################################
+#  Full image
+###########################################
+FROM dev AS full
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Install the full release
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ros-rolling-desktop \
+  && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=
+ENV LD_LIBRARY_PATH=/opt/ros/rolling/lib
+
+###########################################
+#  Full+Gazebo image
+###########################################
+FROM full AS gazebo
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Install gazebo
+RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
+  && apt-get update && apt-get install -q -y --no-install-recommends \
+    ros-rolling-ros-gz \
+  && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=

--- a/templates.yml
+++ b/templates.yml
@@ -79,6 +79,21 @@ ros2:
     base_image: "ubuntu"
     image_version: "24.04"
   -
+    name: rolling-cuda
+    ros_distro: rolling
+    targets:
+      - target: base
+        platforms: "linux/amd64"
+      - target: dev
+        platforms: "linux/amd64"
+      - target: full
+        platforms: "linux/amd64"
+      - target: gazebo
+        platforms: "linux/amd64"
+    python_version: "3.12"
+    base_image: "nvidia/cuda"
+    image_version: "12.6.2-cudnn-runtime-ubuntu24.04"
+  -
     name: jazzy
     ros_distro: jazzy
     targets:


### PR DESCRIPTION
Added a rolling-cuda image based on `nvidia/cuda:12.6.2-cudnn-runtime-ubuntu24.04`. My host machine is still on CUDA 11.8, but you can get around that by setting `NVIDIA_DISABLE_REQUIRE=1` to skip the CUDA version check.  

I'm using this image daily for development and with the [vscode_ros2_workspace](https://github.com/athackst/vscode_ros2_workspace)---btw, awesome template! If you're using it too, just add the following line to the container environment variables in `.devcontainer/devcontainer.json` file [HERE](https://github.com/athackst/vscode_ros2_workspace/blob/7c91849a26201d0e768287d5d13b2380e2c0b7ea/.devcontainer/devcontainer.json#L21)

```json
"NVIDIA_DISABLE_REQUIRE": "1", // Skips CUDA version check if your host CUDA version < 12.6
```

This setup works smoothly for me and gz Ionic is running on the GPU—hope it helps you too!