### PR TITLE
Update workflows for all pull request tests in test.yml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,44 +1,21 @@
 name: Dockerfiles
-# Test and push dockerfiles when they change.
-# Test for pull request, push dockerfiles when merged into main.
+# Test and push dockerfiles when merged into main and on schedule.
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: "0 0 1 * *"
   push:
     branches:
       - main
-    paths:
-      - '**.Dockerfile'
-      - .github/workflows/docker.yml
-  pull_request_target:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 0 1 * *"
   workflow_dispatch:
 
 # Cancel in-progress funs of the same workflow
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  generate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-          cache: pip
-      - name: Verify dockerfiles
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          ./generate.py
-          git diff --exit-code
-
   docker:
-    needs: generate
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -230,13 +207,6 @@ jobs:
             platforms: "linux/amd64"
     steps:
       - uses: actions/checkout@v4
-      - name: Filter build
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            docker:
-              - ${{ matrix.label }}/${{ matrix.tag }}.Dockerfile
       - name: Set current date
         id: date
         run: |
@@ -261,9 +231,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
-        if: ${{ steps.filter.outputs.docker == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         with:
-          push: ${{ github.ref == 'refs/heads/main' }}
           file: ${{ matrix.label }}/${{ matrix.tag }}.Dockerfile
           target: ${{ matrix.target }}
           platforms: ${{ matrix.platforms }}
@@ -277,12 +245,3 @@ jobs:
           cache-to: |
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.label }}:${{ matrix.tag }}-buildcache,mode=max
             type=gha,mode=max
-
-  complete:
-    needs:
-      - generate
-      - docker
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check
-        run: echo "Completed successfully!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 
@@ -28,6 +25,23 @@ jobs:
         run: |
           pip install pydocstyle
           pydocstyle .
+
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          cache: pip
+      - name: Verify dockerfiles
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          ./generate.py
+          git diff --exit-code
+
   env-check:
     runs-on: ubuntu-latest
     permissions:
@@ -59,3 +73,62 @@ jobs:
       - name: Run environment comparison
         run: |
           .github/scripts/env-compare.py app:local rolling
+
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required to analyze file changes
+    outputs:
+      dockerfiles: ${{ steps.filter.outputs.dockerfiles }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Find Changed Dockerfiles
+        id: filter
+        run: |
+          # Find changed .Dockerfile files between the PR branch and the base branch
+          changed_files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.Dockerfile')
+          echo "Changed Dockerfiles: $changed_files"
+
+          # Output the results as JSON
+          if [ -z "$changed_files" ]; then
+            echo '["none"]' > changed_dockerfiles.json
+          else
+            echo "$changed_files" | jq -R -s -c 'split("\n")[:-1]' > changed_dockerfiles.json
+          fi
+          echo "dockerfiles=$(cat changed_dockerfiles.json)" >> $GITHUB_OUTPUT
+
+  docker-build:
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: ${{ fromJSON(needs.changes.outputs.dockerfiles) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Test dockerfile build
+        if: ${{ matrix.dockerfile != 'none' }}
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          file: ${{ matrix.dockerfile }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.label }}:${{ matrix.tag }}-buildcache
+            type=gha
+          cache-to:            
+            type=gha,mode=max
+
+  complete:
+    needs:
+      - lint
+      - generate
+      - env-check
+      - docker-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        run: echo "Completed successfully!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,12 +53,6 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -109,17 +103,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4    
+      - name: Extract Label and Tag
+        id: extract
+        run: |
+          # Extract the full filename (e.g., label/tag.Dockerfile)
+          filename="${{ matrix.dockerfile }}"
+          
+          # Extract label (e.g., 'label')
+          label=$(dirname "$filename")
+          
+          # Extract tag (e.g., 'tag')
+          tag=$(basename "$filename" | cut -d. -f1)
+          
+          echo "Label: $label, Tag: $tag"
+          
+          # Set outputs for subsequent steps
+          echo "label=$label" >> $GITHUB_OUTPUT
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Test dockerfile build
         if: ${{ matrix.dockerfile != 'none' }}
         uses: docker/build-push-action@v6
         with:
           push: false
           file: ${{ matrix.dockerfile }}
+          tags: |
+             ghcr.io/${{ github.repository_owner }}/${{ steps.extract.outputs.label }}:${{ steps.extract.outputs.tag }}
           cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.label }}:${{ matrix.tag }}-buildcache
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ steps.extract.outputs.label }}:${{ steps.extract.outputs.tag }}-buildcache
             type=gha
-          cache-to:            
+          cache-to:
             type=gha,mode=max
 
   complete:

--- a/ros2/jazzy.Dockerfile
+++ b/ros2/jazzy.Dockerfile
@@ -1,5 +1,5 @@
 ##############################################
-# Created from template ros2.dockerfile.jinja
+# Created from template ros2.dockerfile.jinja test
 ##############################################
 
 ###########################################

--- a/ros2/jazzy.Dockerfile
+++ b/ros2/jazzy.Dockerfile
@@ -1,5 +1,5 @@
 ##############################################
-# Created from template ros2.dockerfile.jinja test
+# Created from template ros2.dockerfile.jinja
 ##############################################
 
 ###########################################


### PR DESCRIPTION
Since forked PRs can't use secrets, this change moves just a build test for the dockerfiles that are changed to a read-only test flow and the build + push docker action is then updated to be used only when merging to main or on a schedule.